### PR TITLE
Small readme example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ class Article {
 class ArticleCollection {
   articles: Article[] = [];
   getArticle(id: number) {
-    console.log(`Setting article with id: ${id}.`);
+    console.log(`Getting article with id: ${id}.`);
     return this.articles.filter(a => {
       return a.id === id;
     }).pop();
@@ -49,7 +49,7 @@ new ArticleCollection().getArticle(1);
 
 // Result:
 // Inside of the logger. Called ArticleCollection.getArticle with args: 1.
-// Setting article with id: 1.
+// Getting article with id: 1.
 ```
 
 


### PR DESCRIPTION
Fix readme documentation.
Shows and logs the getArticle as "setting article" changed to "getting article"