### PR TITLE
extend method metadata with invoke method - fixes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ export class MethodMetadata {
   public context: any;
   public result: any;
   public exception: any;
+  public invoke: (...args: any[]) => any;
 }
 ```
 

--- a/lib/src/core/joint_point.ts
+++ b/lib/src/core/joint_point.ts
@@ -19,14 +19,15 @@ export abstract class JointPoint {
     });
   }
 
-  protected getMetadata(className: string, key: string, args: IArguments, context: any, woveMetadata: any): Metadata {
+  protected getMetadata(className: string, key: string, fn: any, args: IArguments, context: any, woveMetadata: any): Metadata {
     var invocation: MethodMetadata = {
       name: key,
       proceed: true,
       context: context,
       result: undefined,
       exception: undefined,
-      args: undefined
+      args: undefined,
+      invoke: () => fn.apply(context, args)
     };
     var metadata: Metadata = new Metadata();
     metadata.method = invocation;

--- a/lib/src/core/joint_point.ts
+++ b/lib/src/core/joint_point.ts
@@ -27,7 +27,7 @@ export abstract class JointPoint {
       result: undefined,
       exception: undefined,
       args: undefined,
-      invoke: () => fn.apply(context, args)
+      invoke: fn.bind(context)
     };
     var metadata: Metadata = new Metadata();
     metadata.method = invocation;

--- a/lib/src/core/metadata.ts
+++ b/lib/src/core/metadata.ts
@@ -5,7 +5,7 @@ export class MethodMetadata {
   public context: any;
   public result: any;
   public exception: any;
-  public invoke: () => any;
+  public invoke: (...args: any[]) => any;
 }
 
 export class Metadata {

--- a/lib/src/core/metadata.ts
+++ b/lib/src/core/metadata.ts
@@ -5,6 +5,7 @@ export class MethodMetadata {
   public context: any;
   public result: any;
   public exception: any;
+  public invoke: () => any;
 }
 
 export class Metadata {

--- a/lib/src/joint_points/accessor_use.ts
+++ b/lib/src/joint_points/accessor_use.ts
@@ -21,7 +21,7 @@ export class AccessorJointPoint extends JointPoint {
     if (typeof descriptor[this.type] === 'function') {
       let bak = descriptor[this.type];
       descriptor[this.type] = function () {
-        let metadata = self.getMetadata(className, key, arguments, this, woveMetadata);
+        let metadata = self.getMetadata(className, key, bak, arguments, this, woveMetadata);
         return advice.wove(bak, metadata);
       };
       descriptor[this.type]['__woven__'] = true;

--- a/lib/src/joint_points/method_call.ts
+++ b/lib/src/joint_points/method_call.ts
@@ -35,7 +35,7 @@ export class MethodCallJointPoint extends JointPoint {
     let bak = proto[key];
     let self = this;
     proto[key] = function () {
-      let metadata = self.getMetadata(className, key, arguments, this, woveMetadata);
+      let metadata = self.getMetadata(className, key, bak, arguments, this, woveMetadata);
       return advice.wove(bak, metadata);
     };
     proto[key].__woven__ = true;

--- a/lib/src/joint_points/static_method.ts
+++ b/lib/src/joint_points/static_method.ts
@@ -32,7 +32,7 @@ export class StaticMethodJointPoint extends JointPoint {
     let bak = fn[key];
     let self = this;
     fn[key] = function () {
-      let metadata = self.getMetadata(className, key, arguments, this, woveMetadata);
+      let metadata = self.getMetadata(className, key, bak, arguments, this, woveMetadata);
       return advice.wove(bak, metadata);
     };
     fn[key].__woven__ = true;

--- a/test/advices/sync_advices.spec.ts
+++ b/test/advices/sync_advices.spec.ts
@@ -2,7 +2,7 @@ import {Metadata, MethodMetadata, Wove, resetRegistry} from '../../lib/src/core'
 import {Advice} from '../../lib/src/core/advice';
 import * as SyncAdvices from '../../lib/src/advices';
 
-import {beforeMethod, afterMethod} from '../../lib/aspect';
+import {beforeMethod, beforeStaticMethod, beforeGetter, afterMethod} from '../../lib/aspect';
 
 import {expect} from 'chai';
 
@@ -25,6 +25,7 @@ describe('sync advices', () => {
           expect(metadata.className).to.equal('Demo');
           expect(metadata.method.name).to.equal('get');
           expect(metadata.method.args).to.deep.equal([42, 1.618]);
+          expect(metadata.method.invoke).to.be.a('function');
           done();
         }
       }
@@ -56,6 +57,82 @@ describe('sync advices', () => {
         }
       }
       new Demo().get();
+    });
+
+    it('should be able to invoke the method manually', (done) => {
+      let demo;
+      let called = 0;
+      class Aspect {
+        @beforeMethod({ classNamePattern: /.*/, methodNamePattern: /.*/ })
+        before(metadata: Metadata) {
+          metadata.method.proceed = false;
+          metadata.method.result = metadata.method.invoke();
+          expect(metadata.method.result).to.be.equal(6);
+        }
+      }
+      @Wove()
+      class Demo {    
+        multiplier = 2;
+        get(foo, bar) {
+          called++;
+          return (foo + bar) * this.multiplier;
+        }
+      }
+
+      demo = new Demo();
+      expect(demo.get(1, 2)).to.be.equal(6);
+      expect(called).to.be.equal(1);
+      done();
+    });
+
+    it('should be able to invoke the static method manually', (done) => {
+      let called = 0;
+      class Aspect {
+        @beforeStaticMethod({ classNamePattern: /.*/, methodNamePattern: /.*/ })
+        before(metadata: Metadata) {
+          metadata.method.proceed = false;
+          metadata.method.result = metadata.method.invoke();
+          expect(metadata.method.result).to.be.equal(3);
+        }
+      }
+      @Wove()
+      class Demo {    
+        static get(foo, bar) {
+          called++;
+          return foo + bar ;
+        }
+      }
+
+      expect(Demo.get(1, 2)).to.be.equal(3);
+      expect(called).to.be.equal(1);
+      done();
+    });
+
+    it('should be able to invoke the getter manually', (done) => {
+      let demo;
+      let called = 0;
+      class Aspect {
+        @beforeGetter({ classNamePattern: /.*/, fieldNamePattern: /.*/ })
+        before(metadata: Metadata) {
+          metadata.method.proceed = false;
+          const result = metadata.method.invoke();
+          metadata.method.result = result * 2;
+          expect(result).to.be.equal(5);
+        }
+      }
+      @Wove()
+      class Demo {    
+        get foo() {
+          called++;
+          return 5;
+        }
+      }
+
+      demo = new Demo();
+
+      expect(demo.foo).to.be.equal(10);
+      expect(called).to.be.equal(1);
+      done();
     });
 
   });

--- a/test/advices/sync_advices.spec.ts
+++ b/test/advices/sync_advices.spec.ts
@@ -66,12 +66,12 @@ describe('sync advices', () => {
         @beforeMethod({ classNamePattern: /.*/, methodNamePattern: /.*/ })
         before(metadata: Metadata) {
           metadata.method.proceed = false;
-          metadata.method.result = metadata.method.invoke();
+          metadata.method.result = metadata.method.invoke(...metadata.method.args);
           expect(metadata.method.result).to.be.equal(6);
         }
       }
       @Wove()
-      class Demo {    
+      class Demo {
         multiplier = 2;
         get(foo, bar) {
           called++;
@@ -91,19 +91,42 @@ describe('sync advices', () => {
         @beforeStaticMethod({ classNamePattern: /.*/, methodNamePattern: /.*/ })
         before(metadata: Metadata) {
           metadata.method.proceed = false;
-          metadata.method.result = metadata.method.invoke();
+          metadata.method.result = metadata.method.invoke(...metadata.method.args);
           expect(metadata.method.result).to.be.equal(3);
         }
       }
       @Wove()
-      class Demo {    
+      class Demo {
+        static get(foo, bar) {
+          called++;
+          return foo + bar;
+        }
+      }
+
+      expect(Demo.get(1, 2)).to.be.equal(3);
+      expect(called).to.be.equal(1);
+      done();
+    });
+
+    it('should be able to invoke the static method manually with custom arguments', (done) => {
+      let called = 0;
+      class Aspect {
+        @beforeStaticMethod({ classNamePattern: /.*/, methodNamePattern: /.*/ })
+        before(metadata: Metadata) {
+          metadata.method.proceed = false;
+          metadata.method.result = metadata.method.invoke(2, 3);
+          expect(metadata.method.result).to.be.equal(5);
+        }
+      }
+      @Wove()
+      class Demo {
         static get(foo, bar) {
           called++;
           return foo + bar ;
         }
       }
 
-      expect(Demo.get(1, 2)).to.be.equal(3);
+      expect(Demo.get(1, 2)).to.be.equal(5);
       expect(called).to.be.equal(1);
       done();
     });
@@ -115,13 +138,13 @@ describe('sync advices', () => {
         @beforeGetter({ classNamePattern: /.*/, fieldNamePattern: /.*/ })
         before(metadata: Metadata) {
           metadata.method.proceed = false;
-          const result = metadata.method.invoke();
+          const result = metadata.method.invoke(metadata.method.args);
           metadata.method.result = result * 2;
           expect(result).to.be.equal(5);
         }
       }
       @Wove()
-      class Demo {    
+      class Demo {
         get foo() {
           called++;
           return 5;


### PR DESCRIPTION
I added `metadata.method.invoke` function that will call the original function (#19).

So now when doing the PR, I noticed that the arguments are fixed. It's not possible to do something like `metadata.method.invoke(1, 2)` as `invoke` will call the original function with the original parameters. So maybe I should refactor this PR to something like this

If you want to use the original arguments, you can call `invoke` like this.

```js
metadata.method.result = metadata.method.invoke(...metadata.method.args);
```

If you want to use other arguments, you can call it like this

```js
metadata.method.result = metadata.method.invoke(1, 2);
```

Feedback?