### PR TITLE
feat: automatically weave classes - fixes #39

### DIFF
--- a/lib/src/core/wove.ts
+++ b/lib/src/core/wove.ts
@@ -1,16 +1,20 @@
 import {AspectRegistry, Targets} from './aspect';
 
+export function weave(target, config?: any) {
+  if (target.__woven__) {
+    return;
+  }
+  let keys = Object.getOwnPropertyNames(AspectRegistry);
+  keys.forEach(key => {
+    AspectRegistry[key].wove(target, config);
+  });
+  Targets.add({ target, config });
+  target.__woven__ = true;
+  return target;
+}
+
 export function Wove(config?: any) {
   return function (target) {
-    if (target.__woven__) {
-      return;
-    }
-    let keys = Object.getOwnPropertyNames(AspectRegistry);
-    keys.forEach(key => {
-      AspectRegistry[key].wove(target, config);
-    });
-    Targets.add({ target, config });
-    target.__woven__ = true;
-    return target;
+    return weave(target, config);
   };
 }

--- a/lib/src/joint_points/preconditions.ts
+++ b/lib/src/joint_points/preconditions.ts
@@ -1,8 +1,15 @@
 import {Precondition} from '../core/joint_point';
 import {MethodSelector, MemberSelector} from './selectors';
+import {weave} from '../core/wove';
 
 export class MethodPrecondition implements Precondition {
-  constructor(private selector: MethodSelector) {}
+  constructor(private selector: MethodSelector) {
+    // Automatically weave classes
+    const classes = selector.classes || [];
+    for (const c of classes) {
+      weave(c);
+    }
+  }
 
   assert({classInstance, methodName}): boolean {
     const s = this.selector;

--- a/test/advices/sync_advices.spec.ts
+++ b/test/advices/sync_advices.spec.ts
@@ -227,4 +227,53 @@ describe('sync advices', () => {
     });
 
   });
+
+  describe('Wove', () => {
+    it('should pass the Wove config as `woveMetadata`', () => {
+      let adviceCalls = 0;
+
+      @Wove({foo: 'bar'})
+      class Demo {
+        get() {}
+        set() {}
+      }
+
+      class Aspect {
+        @beforeMethod({ classes: [Demo], methodNamePattern: /get/ })
+        before(metadata: Metadata) {
+          expect(metadata.woveMetadata).to.deep.equal({foo: 'bar'});
+          adviceCalls += 1;
+        }
+      }
+      const demo = new Demo();
+      demo.get();
+      expect(adviceCalls).to.eq(1);
+    });
+
+    it('should weave automatically when using classes', () => {
+      let adviceCalls = 0;
+
+      class Demo {
+        get() {}
+        set() {}
+      }
+
+      class Aspect {
+        @beforeMethod({ classes: [Demo], methodNamePattern: /get/ })
+        before(metadata: Metadata) {
+          adviceCalls += 1;
+        }
+        @afterMethod({ classes: [Demo], methodNamePattern: /set/ })
+        after(metadata: Metadata) {
+          adviceCalls += 1;
+        }
+      }
+      const demo = new Demo();
+      demo.get();
+      expect(adviceCalls).to.eq(1);
+      demo.set();
+      expect(adviceCalls).to.eq(2);
+    });
+
+  });
 });


### PR DESCRIPTION
This PR implements #39 which automatically woves the target when `classes` is being used.