### PR TITLE
chore: use Map to register aspects

### DIFF
--- a/lib/src/core/aspect.ts
+++ b/lib/src/core/aspect.ts
@@ -1,11 +1,11 @@
 import {Pointcut} from './pointcut';
 
-export let AspectRegistry: { [name: string]: Aspect; } = {};
+export let AspectRegistry = new Map<string, Aspect>();
 
-export let Targets: Set<any> = new Set<any>();
+export let Targets = new Set<any>();
 
 export function resetRegistry() {
-  AspectRegistry = {};
+  AspectRegistry = new Map<string, Aspect>();
   Targets = new Set<any>();
 }
 

--- a/lib/src/core/wove.ts
+++ b/lib/src/core/wove.ts
@@ -4,10 +4,11 @@ export function weave(target, config?: any) {
   if (target.__woven__) {
     return;
   }
-  let keys = Object.getOwnPropertyNames(AspectRegistry);
-  keys.forEach(key => {
-    AspectRegistry[key].wove(target, config);
-  });
+
+  for (const aspect of Array.from(AspectRegistry.values())) {
+    aspect.wove(target, config);
+  }
+
   Targets.add({ target, config });
   target.__woven__ = true;
   return target;

--- a/lib/src/joint_points/accessor_use.ts
+++ b/lib/src/joint_points/accessor_use.ts
@@ -54,9 +54,9 @@ export function makeFieldGetAdviceDecorator(constr) {
       pointcut.advice = <Advice>new constr(target, descriptor.value);
       pointcut.jointPoints = jointpoints;
       let aspectName = target.constructor.name;
-      let aspect = AspectRegistry[aspectName] || new Aspect();
+      let aspect = AspectRegistry.get(aspectName) || new Aspect();
       aspect.pointcuts.push(pointcut);
-      AspectRegistry[aspectName] = aspect;
+      AspectRegistry.set(aspectName, aspect);
       return target;
     }
   }

--- a/lib/src/joint_points/method_call.ts
+++ b/lib/src/joint_points/method_call.ts
@@ -52,9 +52,9 @@ export function makeMethodCallAdviceDecorator(constr) {
       pointcut.advice = <Advice>new constr(target, descriptor.value);
       pointcut.jointPoints = jointpoints;
       let aspectName = target.constructor.name;
-      let aspect = AspectRegistry[aspectName] || new Aspect();
+      let aspect = AspectRegistry.get(aspectName) || new Aspect();
       aspect.pointcuts.push(pointcut);
-      AspectRegistry[aspectName] = aspect;
+      AspectRegistry.set(aspectName, aspect);
       // For lazy loading
       Targets.forEach(({ target, config}) => aspect.wove(target, config));
       return target;

--- a/lib/src/joint_points/static_method.ts
+++ b/lib/src/joint_points/static_method.ts
@@ -49,9 +49,9 @@ export function makeStaticMethodAdviceDecorator(constr) {
       pointcut.advice = <Advice>new constr(target, descriptor.value);
       pointcut.jointPoints = jointpoints;
       let aspectName = target.constructor.name;
-      let aspect = AspectRegistry[aspectName] || new Aspect();
+      let aspect = AspectRegistry.get(aspectName) || new Aspect();
       aspect.pointcuts.push(pointcut);
-      AspectRegistry[aspectName] = aspect;
+      AspectRegistry.set(aspectName, aspect);
       Targets.forEach(({ target, config}) => aspect.wove(target, config));
       return target;
     }


### PR DESCRIPTION
I think it's cleaner if we used a `Map` instead of a old-school object-map to register aspects. Feel free to reject though, was just an idea when navigating through the code.