### PR TITLE
Fix: set field advice decorator

### DIFF
--- a/lib/src/joint_points/accessor_use.ts
+++ b/lib/src/joint_points/accessor_use.ts
@@ -72,9 +72,9 @@ export function makeFieldSetAdviceDecorator(constr) {
       pointcut.advice = <Advice>new constr(target, descriptor.value);
       pointcut.jointPoints = jointpoints;
       let aspectName = target.constructor.name;
-      let aspect = AspectRegistry[aspectName] || new Aspect();
+      let aspect = AspectRegistry.get(aspectName) || new Aspect();
       aspect.pointcuts.push(pointcut);
-      AspectRegistry[aspectName] = aspect;
+      AspectRegistry.set(aspectName, aspect);
       Targets.forEach(({ target, config}) => aspect.wove(target, config));
       return target;
     }

--- a/test/advices/sync_advices.spec.ts
+++ b/test/advices/sync_advices.spec.ts
@@ -2,7 +2,7 @@ import {Metadata, MethodMetadata, Wove, resetRegistry} from '../../lib/src/core'
 import {Advice} from '../../lib/src/core/advice';
 import * as SyncAdvices from '../../lib/src/advices';
 
-import {beforeMethod, beforeStaticMethod, beforeGetter, afterMethod} from '../../lib/index';
+import {beforeMethod, beforeStaticMethod, beforeGetter, beforeSetter, afterMethod} from '../../lib/index';
 
 import {expect} from 'chai';
 
@@ -154,6 +154,38 @@ describe('sync advices', () => {
       demo = new Demo();
 
       expect(demo.foo).to.be.equal(10);
+      expect(called).to.be.equal(1);
+      done();
+    });
+
+    it('should be able to invoke the setter manually', (done) => {
+      let demo;
+      let called = 0;
+      class Aspect {
+        @beforeSetter({ classNamePattern: /.*/, fieldNamePattern: /.*/ })
+        before(metadata: Metadata) {
+          metadata.method.proceed = false;
+          metadata.method.invoke('rainbow');
+        }
+      }
+      @Wove()
+      class Demo {
+        private fooValue;
+
+        set foo(value) {
+          called++;
+          this.fooValue = value;
+        }
+
+        get foo() {
+          return this.fooValue;
+        }
+      }
+
+      demo = new Demo();
+      demo.foo = 'bar';
+
+      expect(demo.foo).to.be.equal('rainbow');
       expect(called).to.be.equal(1);
       done();
     });


### PR DESCRIPTION
I noticed that I forgot to change the `set field advice`. Also added a test for that one because otherwise it would've catched it :).