### PR TITLE
feat: implement decorator selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,13 @@ This way, by explicitly listing the classes and methods which should be woven, y
 
 # Sample usage (decorators)
 
-To use advice using custom decorators, you can use the `makeMethodDecorator()` and `makeMemberDecorator()` functions. Here's an example:
+Here's an example using custom decorators and reflect-metadata:
 
 ```ts
-import { makeMethodDecorator } from 'aspect.js';
-
 export const Log = (message?: string) => {
-  return makeMethodDecorator(((target: object, propertyKey: string | symbol) => {
+  return (target: object, propertyKey: string | symbol) => {
     Reflect.defineMetadata(Log, { message }, target, propertyKey);
-  });
+  };
 };
 
 class LoggerAspect {
@@ -118,6 +116,7 @@ class Article {
   content: string;
 }
 
+@Advised()
 class ArticleCollection {
   articles: Article[] = [];
 

--- a/lib/src/join_points/preconditions.ts
+++ b/lib/src/join_points/preconditions.ts
@@ -33,7 +33,10 @@ export class MethodPrecondition implements Precondition {
     if (s.decorators) {
       const d = Object.getOwnPropertyDescriptor(classDefinition.prototype, methodName);
       matchDecorator = s.decorators.some(decorator => {
-        return !d.get && !d.set && Reflect.hasMetadata(decorator, classDefinition.prototype, methodName);
+        return !d.get && !d.set && (
+          Reflect.hasMetadata(decorator, classDefinition.prototype, methodName) ||
+          Reflect.hasMetadata(decorator, classDefinition.prototype[methodName])
+        );
       });
     }
 

--- a/lib/src/join_points/selectors.ts
+++ b/lib/src/join_points/selectors.ts
@@ -1,13 +1,19 @@
+export type MethodDecoratorFactory = (...args: any[]) => MethodDecorator;
+
 export interface MethodSelector {
   classNamePattern?: RegExp;
   methodNamePattern?: RegExp;
   classes?: Function[];
   methods?: Function[];
+  decorators?: (MethodDecorator | MethodDecoratorFactory)[];
 }
+
+export type PropertyDecoratorFactory = (...args: any[]) => PropertyDecorator;
 
 export interface PropertySelector {
   classNamePattern?: RegExp;
   propertyNamePattern?: RegExp;
   classes?: Function[];
   properties?: PropertyDescriptor[];
+  decorators?: (MethodDecorator | MethodDecoratorFactory)[];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,12 @@
       "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
       "dev": true
     },
+    "reflect-metadata": {
+      "version": "0.1.12",
+      "resolved": "http://repository.vnerd.com/artifactory/api/npm/npm-pluralsight/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha1-MRvwxrY814LyKKgavhRqK/qcVvI=",
+      "dev": true
+    },
     "rxjs": {
       "version": "5.5.6",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",

--- a/package.json
+++ b/package.json
@@ -39,11 +39,15 @@
     "chai": "^3.3.0",
     "mocha": "^5.2.0",
     "prettier": "^1.7.4",
+    "reflect-metadata": "^0.1.12",
     "rxjs": "^5.2.0",
     "sinon": "^4.4.2",
     "ts-node": "^7.0.1",
     "tsviz": "^1.0.11",
     "typescript": "^2.0.2",
     "zone.js": "^0.7.7"
+  },
+  "peerDependencies": {
+    "reflect-metadata": "^0.1.12"
   }
 }

--- a/test/core/preconditions.spec.ts
+++ b/test/core/preconditions.spec.ts
@@ -164,8 +164,8 @@ describe('Preconditions', () => {
       };
 
       const FooBar = (options: { value: string }) => {
-        return (target: object, propertyKey: string | symbol) => {
-          Reflect.defineMetadata(FooBar, { propertyKey, args: options }, target, propertyKey);
+        return (target: object, propertyKey: string | symbol, propertyDescriptor: PropertyDescriptor) => {
+          Reflect.defineMetadata(FooBar, { propertyKey, args: options }, propertyDescriptor.value);
         };
       };
 
@@ -203,12 +203,13 @@ describe('Preconditions', () => {
       const p1 = new MethodPrecondition({
         classes: [ClassA, Foo],
         methodNamePattern: /yep/,
-        decorators: [Bar, Baz]
+        decorators: [Bar, Baz, FooBar]
       });
       expect(p1.assert({ classDefinition: Foo, methodName: 'bar' })).equal(false);
       expect(p1.assert({ classDefinition: Foo, methodName: 'baz' })).equal(true);
-      expect(p1.assert({ classDefinition: Foo, methodName: 'foobar' })).equal(false);
+      expect(p1.assert({ classDefinition: Foo, methodName: 'foobar' })).equal(true);
       expect(p1.assert({ classDefinition: Foo, methodName: 'nope' })).equal(false);
+      expect(p1.assert({ classDefinition: Foo, methodName: 'yep' })).equal(true);
       expect(p1.assert({ classDefinition: Foo, methodName: 'yep' })).equal(true);
       expect(p1.assert({ classDefinition: ClassA, methodName: 'yep' })).equal(true);
     });


### PR DESCRIPTION
Updated PR, similar to: https://github.com/mgechev/aspect.js/pull/58. Description has been copied here for convenience:

This adds the ability to apply advice using decorators. Here's an example logging aspect that allows adding custom messages through method decorators:
```ts
const Log = (message: string) => {
  return (target: object, propertyKey: string | symbol) => {
    Reflect.defineMetadata(Log, { message }, target, propertyKey);
  };
};

@Advised()
class ClassC {
  @Log('Foo was called')
  foo() {}
}

class LoggerAspect {
  @beforeMethod({
    decorators: [Log],
  })
  beforeLogger(meta: Metadata) {
    const { message } = Reflect.getMetadata(Log, meta.method.context, meta.method.name);
    console.log(message);
  }
}
```

This is a proof of concept, and could probably use additional tests. If there's interest in adding this feature to the library, I can make any suggested changes.